### PR TITLE
Rails 5 support

### DIFF
--- a/bulk_data_methods.gemspec
+++ b/bulk_data_methods.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.homepage     = 'http://github.com/fiksu/bulk_data_methods'
   s.add_dependency "pg"
-  s.add_dependency "activerecord", '>= 3.0', '< 5.0'
-  s.add_development_dependency "rails", '>= 3.0', '< 5.0'
+  s.add_dependency "activerecord", '>= 3.0'
+  s.add_development_dependency "rails", '>= 3.0'
   s.add_development_dependency "rspec-rails"
 end

--- a/lib/bulk_data_methods/bulk_methods_mixin.rb
+++ b/lib/bulk_data_methods/bulk_methods_mixin.rb
@@ -97,7 +97,7 @@ module BulkMethodsMixin
           end
         end
         column_values = column_names.map do |column_name|
-          quote_value(row[column_name], columns_hash[column_name.to_s])
+          bulk_methods_quote_value(columns_hash[column_name.to_s], row[column_name])
         end.join(',')
         "(#{column_values})"
       end.each_slice(options[:slice_size]) do |insert_slice|
@@ -226,9 +226,9 @@ module BulkMethodsMixin
             column_name = column_name.to_s
             columns_hash_value = columns_hash[column_name]
             if i == 0
-              "#{quote_value(column_value, columns_hash_value)}::#{columns_hash_value.sql_type} as #{column_name}"
+              "#{bulk_methods_quote_value(columns_hash_value, column_value)}::#{columns_hash_value.sql_type} as #{column_name}"
             else
-              quote_value(column_value, columns_hash_value)
+              bulk_methods_quote_value(columns_hash_value, column_value)
             end
           end.join(',')
         end
@@ -250,5 +250,13 @@ module BulkMethodsMixin
       end
     end
     return returning
+  end
+
+  def bulk_methods_quote_value(postgre_sql_column, column_value)
+    if Rails.version >= '5.0.0'
+      connection.quote connection.type_cast_from_column(postgre_sql_column, column_value)
+    else
+      quote_value(column_value, postgre_sql_column)
+    end
   end
 end


### PR DESCRIPTION
allow to use any rails version from 3 and above
rails5 does not do typecasting anymore during quoting, add bulk_methods_quote_value that uses rails4 behaviour
it was removed from rails in following commit:
https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11